### PR TITLE
Additional config support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,6 @@
 /*
  * grunt-proxy
- * 
+ *
  *
  * Copyright (c) 2012 Andrei V. Toutoukine
  * Licensed under the MIT license.
@@ -15,16 +15,16 @@ module.exports = function(grunt) {
 			gruntfile	: {
 				src	: 'Gruntfile.js'
 			},
-			
+
 			tasks		: {
 				src	: ['tasks/**/*.js']
 			},
-			
+
 			tests		: {
 				src	: ['test/*.js'],
 				options : {jshintrc:'test/.jshintrc'}
 			},
-			
+
 			options: {
 				jshintrc: '.jshintrc',
 			},
@@ -56,7 +56,7 @@ module.exports = function(grunt) {
 				}
 			}
 		},
-		
+
 		// Test servers
 		connect: {
 			host1:	{
@@ -74,28 +74,25 @@ module.exports = function(grunt) {
 		},
 
 		// Unit tests.
-		simplemocha : {
-			options		: {
-				reporter : 'spec'
-			},
+		mochaTest : {
 			all : { src : '<%= jshint.tests.src %>' },
 			unit: { src : 'test/unit_test.js'}
 		},
-		
+
 		watch : {
 			gruntfile	: {
 				files		: '<%= jshint.gruntfile.src %>',
 				tasks		: ['jshint:gruntfile']
 			},
-			
+
 			tasks		: {
 				files		: '<%= jshint.tasks.src %>',
-				tasks		: ['jshint:tasks','simplemocha:unit']
+				tasks		: ['jshint:tasks','mochaTest:unit']
 			},
-			
+
 			tests		: {
 				files		: '<%= jshint.tests.src %>',
-				tasks		: ['jshint:tests','simplemocha:unit']
+				tasks		: ['jshint:tests','mochaTest:unit']
 			}
 		}
 
@@ -109,11 +106,11 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-clean');
 	grunt.loadNpmTasks('grunt-contrib-connect');
 	grunt.loadNpmTasks('grunt-contrib-watch');
-	grunt.loadNpmTasks('grunt-simple-mocha');
+	grunt.loadNpmTasks('grunt-mocha-test');
 
 	// Whenever the "test" task is run, first clean the "tmp" dir, then run this
 	// plugin's task(s), then test the result.
-	grunt.registerTask('test', ['clean', 'connect', 'proxy', 'simplemocha:all']);
+	grunt.registerTask('test', ['clean', 'connect', 'proxy', 'mochaTest:unit']);
 
 	// By default, lint and run all tests.
 	grunt.registerTask('default', ['test']);

--- a/README.md
+++ b/README.md
@@ -87,22 +87,15 @@ Default value: none
 
 Proxy table, which is a simple lookup table that maps incoming requests
 to proxy target locations. If options.target is also given the proxy table
-is totally ignored (this behaviour will be changed in the future). 
- 
+is totally ignored (this behaviour will be changed in the future).
+
 ### Usage Examples
 
 see tests
 
 ### Tests
 
-note, if you see
-
-```
-Warning: Arguments to path.resolve must be strings Use --force to continue.
-```
-
-running grunt simplemocha:unit, please apply [patch](https://github.com/SBoudrias/grunt-simple-mocha/commit/8b93f23efa51d8f0a11aa063e64b464c24dbd243)
-to grunt-simple-mocha
+grunt test
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style.

--- a/node_modules/.bin/grunt-simple-mocha
+++ b/node_modules/.bin/grunt-simple-mocha
@@ -1,1 +1,0 @@
-../grunt-simple-mocha/bin/grunt-simple-mocha

--- a/node_modules/.bin/node-http-proxy
+++ b/node_modules/.bin/node-http-proxy
@@ -1,1 +1,0 @@
-../http-proxy/bin/node-http-proxy

--- a/package.json
+++ b/package.json
@@ -2,10 +2,14 @@
   "name": "grunt-proxy",
   "description": "Start proxy server",
   "version": "0.0.2",
+  "repository": "https://github.com/tutukin/grunt-proxy",
   "author": {
     "name": "Andrei V. Toutoukine",
     "email": "tut@isuct.ru"
   },
+  "contributors":[
+    { "name": "Mark Smith", "url": "https://github.com/RallySoftware/grunt-proxy"}
+  ],
   "licenses": [
     {
       "type": "MIT",
@@ -27,7 +31,7 @@
     "grunt-contrib-clean": "0.4.x",
     "grunt-contrib-connect": "0.2.x",
     "grunt": "0.4.x",
-    "grunt-simple-mocha": "0.3.x",
+    "grunt-mocha-test": "~0.6.3",
     "expect.js": "0.2.x",
     "mock":"0.1.x",
     "sinon":"1.6.x",

--- a/tasks/proxy.js
+++ b/tasks/proxy.js
@@ -1,6 +1,6 @@
 /*
  * grunt-proxy
- * 
+ *
  *
  * Copyright (c) 2012 Andrei V. Toutoukine
  * Licensed under the MIT license.
@@ -9,38 +9,39 @@
 'use strict';
 var httpProxy = require('http-proxy');
 
+var DEFAULT_PORT = 9000;
+
 module.exports = function(grunt) {
-	
+
 	grunt.registerMultiTask('proxy', 'Start proxy server', function() {
-		var options = this.options(),  // TODO: defaults?
-			createargs = [],
-			listenargs = [],
+		var options = this.options(),
+			listenPort = DEFAULT_PORT,
+			listenArgs = [],
 			proxy;
-		
-		if ( options.target ) { // TODO: use options config to configure createServer call
-			createargs.push({
-				target : options.target
-			});
+
+		if (options.router) { // TODO: use options config to configure createServer call
+			// setting router supercedes target
+			delete options.target;
 		}
-		else if (options.router) { // TODO: use options config to configure createServer call
-			createargs.push({
-				router : options.router
-			});
+
+		if ( typeof options.port !== 'undefined' ) {
+			// make sure it's really a number
+			if( !isNaN(options.port) ){
+				listenPort = parseInt(options.port, 10);
+			}
+			delete options.port;
 		}
-		
-		if ( typeof options.port === 'undefined' ) {
-			// todo: throw new Error()
-		}
-		
-		listenargs.push(options.port);
-		
+		listenArgs.push(listenPort);
+
+
 		if ( options.host ) {
-			listenargs.push( options.host );
+			listenArgs.push( options.host );
+			delete options.host;
 		}
-		
-		proxy = httpProxy.createServer.apply(httpProxy,createargs);
-		proxy.listen.apply(proxy,listenargs);
-		
+
+		proxy = httpProxy.createServer.call(httpProxy,options);
+		proxy.listen.apply(proxy,listenArgs);
+
 	});
-	
+
 };

--- a/tasks/proxy.js
+++ b/tasks/proxy.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
 			listenArgs = [],
 			proxy;
 
-		if (options.router) { // TODO: use options config to configure createServer call
+		if (options.router) {
 			// setting router supercedes target
 			delete options.target;
 		}

--- a/test/optests.js
+++ b/test/optests.js
@@ -1,16 +1,22 @@
-var	listen	= {
-		host	: 'listen host',
-		port	: 'listen port'
+var	listen = {
+		host : 'listen host',
+		port : '1234',
+		defaultPort: 9000
 	},
-	config	= {
-		host	: 'target host',
-		port	: 'target port',
-		router	: 'routing table',
-		config	: 'a config'
+	config = {
+		host : 'target host',
+		port : 'target port',
+
+		router : 'routing table',
+		https : {
+			key : 'contents of server.key file',
+			cert :'contents of server.crt'
+		},
+		changeOrigin : true
 	};
 
 module.exports = [{
-	
+
 	title	: 'should correctly process options{port,target}',
 	options	: {
 		port : listen.port,
@@ -19,31 +25,81 @@ module.exports = [{
 			port : config.port
 		}
 	},
-	createServer	: [{target : {
-		host	: config.host,
-		port	: config.port
-	}}],
-	listen			: [listen.port]
-	
+	createServer : [{
+		target : {
+			host : config.host,
+			port : config.port
+		}
+	}],
+	listen : [listen.port]
+
 }, {
-	
-	title	: 'should correctly process options{port,router}',
-	options	: {
-		port	: listen.port,
-		router	: config.router
+
+	title : 'should correctly process options{port,router}',
+	options : {
+		port : listen.port,
+		router : config.router
 	},
-	createServer	: [{router:config.router}],
-	listen			: [listen.port]
-	
+	createServer : [{router:config.router}],
+	listen : [listen.port]
+
 }, {
-	
+
 	title	: 'should correctly process options{port,host,router}',
-	options	: {
-		port	: listen.port,
-		host	: listen.host,
-		router	: config.router
+	options : {
+		port : listen.port,
+		host : listen.host,
+		router : config.router
 	},
-	createServer	: [{router:config.router}],
-	listen			: [listen.port,listen.host]
-	
+	createServer : [{router:config.router}],
+	listen : [listen.port,listen.host]
+
+}, {
+
+	title	: 'should correctly pass additional config options {https, changeOrigin}',
+	options : {
+		port : listen.port,
+		router : config.router,
+		https : config.https,
+		changeOrigin: config.changeOrigin
+	},
+	createServer : [{
+		router : config.router,
+		https : config.https,
+		changeOrigin : config.changeOrigin}],
+	listen : [listen.port]
+
+}, {
+
+	title	: 'should default port to 9000 when not supplied',
+	options	: {
+		target : {
+			host : config.host,
+			port : config.port
+		}
+	},
+	createServer	: [{
+		target : {
+			host : config.host,
+			port : config.port
+		}}
+	],
+	listen : [listen.defaultPort]
+}, {
+
+	title	: 'should default port to 9000 when invalid port supplied',
+	options	: {
+		port: "bad port",
+		target : {
+			host : config.host,
+			port : config.port
+		}
+	},
+	createServer	: [{
+		target : {
+			host : config.host,
+			port : config.port
+		}}
+	],
+	listen : [listen.defaultPort]
 }];


### PR DESCRIPTION
Hi,

I made some changes to allow passing additional config parameters to http-proxy.
You can now do things like the following to proxy https services:

```
proxy: {
    proxy1: {
        options: {
            host: 'localhost',
            port: 9000,

            https: {
                key: fs.readFileSync( path.join(proxyKeysDir, 'server.key'), 'utf8' ),
                cert: fs.readFileSync( path.join(proxyKeysDir, 'server.crt'), 'utf8' )
            },
            changeOrigin: true
            router: {
                'localhost/secure': 'https://mysecure.server.com:443/subpath',
                'localhost/insecure/': 'http://127.0.0.1:3000'
            }
        }
    }
}
```

I also added a default port of 9000, changed over to grunt-mocha-test to avoid the warning message and added tests for all the changes.
