### PR TITLE
Added a keepalive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,15 @@ Default value: none
 
 An optional hostname at which the proxy accepts connections.
 
+##### options.keepalive
+Type: `Boolean`
+Default value: false
+
+An optional parameter to specify that the proxy should continue running.
+
 #### Proxy options
 
-All options except for the abovementioned are passed to http-proxy's 
+All options except for the abovementioned are passed to http-proxy's
 `proxy.createServer(options)` method. Please refer to [http-proxy][]
 documentation.
 

--- a/tasks/proxy.js
+++ b/tasks/proxy.js
@@ -15,6 +15,8 @@ module.exports = function(grunt) {
 
 	grunt.registerMultiTask('proxy', 'Start proxy server', function() {
 		var options = this.options(),
+		  done = this.async(),
+			keepAlive = false,
 			listenPort = DEFAULT_PORT,
 			listenArgs = [],
 			proxy;
@@ -22,6 +24,12 @@ module.exports = function(grunt) {
 		if (options.router) {
 			// setting router supercedes target
 			delete options.target;
+		}
+
+		if ( typeof options.keepalive !== 'undefined' ) {
+			// convert to boolean and remove from options
+			keepAlive = !!options.keepalive;
+			delete options.keepalive;
 		}
 
 		if ( typeof options.port !== 'undefined' ) {
@@ -41,6 +49,10 @@ module.exports = function(grunt) {
 
 		proxy = httpProxy.createServer.call(httpProxy,options);
 		proxy.listen.apply(proxy,listenArgs);
+
+		if (!keepAlive) {
+			done();
+		}
 
 	});
 

--- a/test/optests.js
+++ b/test/optests.js
@@ -102,4 +102,21 @@ module.exports = [{
 		}}
 	],
 	listen : [listen.defaultPort]
+}, {
+
+	title: 'should correctly process keepalive',
+	options	: {
+		keepalive: true,
+		target : {
+			host : config.host,
+			port : config.port
+		}
+	},
+	createServer	: [{
+		target : {
+			host : config.host,
+			port : config.port
+		}}
+	],
+	listen : [listen.defaultPort]
 }];

--- a/test/unit_test.js
+++ b/test/unit_test.js
@@ -12,7 +12,8 @@ var	expect	= require('expect.js'),
 		registerMultiTask: sinon.spy()
 	},
 	Context	= {
-		options		: sinon.stub()
+		options		: sinon.stub(),
+		async			: sinon.stub()
 	},
 	optests = require('./optests.js');
 
@@ -28,7 +29,9 @@ describe('grunt-proxy task', function() {
 		Proxy.createServer.reset();
 		Grunt.registerMultiTask.reset();
 		Context.options.reset();
-		
+		Context.async.reset();
+		Context.async.returns(function() { });
+
 		done();
 	});
 	
@@ -83,7 +86,13 @@ describe('grunt-proxy task', function() {
 			expect(Context.options.calledOnce).to.equal(true);
 			done();
 		});
-		
+
+		it('should call this.async()', function(done) {
+			callback.call(Context);
+			expect(Context.async.calledOnce).to.equal(true);
+			done();
+		});
+
 		optests.forEach( function (t) {
 			it(t.title, function (done) {
 				Context.options.returns(t.options);


### PR DESCRIPTION
Added a keepalive option so that you can run the proxy and have it stay open. Otherwise as soon as the proxy task completes the grunt process ends. This is similar to how `grunt-contrib-connect` works.
